### PR TITLE
Recursive `add-dir`

### DIFF
--- a/hooyad/src/client.rs
+++ b/hooyad/src/client.rs
@@ -1,8 +1,13 @@
 use anyhow::Result;
 use clap::{command, value_parser, Arg, ArgAction, Command};
 use dotenv::dotenv;
+use futures_util::future::BoxFuture;
 use hooya::proto::{control_client::ControlClient, FileChunk, TagCidRequest};
-use std::{fs::File, path::Path};
+use std::{
+    fs::File,
+    path::{Path, PathBuf},
+};
+use tonic::transport::Channel;
 mod config;
 
 #[tokio::main]
@@ -17,7 +22,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .default_value(config::DEFAULT_HOOYAD_ENDPOINT),
         )
         .subcommand(
-            Command::new("add").arg(Arg::new("file").action(ArgAction::Append)),
+            Command::new("add").arg(
+                Arg::new("files")
+                    .action(ArgAction::Append)
+                    .value_parser(value_parser!(PathBuf)),
+            ),
+        )
+        .subcommand(
+            Command::new("add-dir").arg(
+                Arg::new("dirs")
+                    .action(ArgAction::Append)
+                    .value_parser(value_parser!(PathBuf)),
+            ),
         )
         .subcommand(
             Command::new("tag").arg(Arg::new("cid").required(true)).arg(
@@ -38,23 +54,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match matches.subcommand() {
         Some(("add", sub_matches)) => {
             let files = sub_matches
-                .get_many::<String>("file")
+                .get_many::<PathBuf>("files")
                 .unwrap_or_default()
-                .map(|v| v.as_str())
                 .collect::<Vec<_>>();
             for f in &files {
-                let fh = File::open(f)?;
-                let chunks = hooya::ChunkedReader::new(fh)
-                    .map(|c| FileChunk { data: c.unwrap() });
-                let resp = client
-                    .stream_to_filestore(futures_util::stream::iter(chunks))
-                    .await?;
-                let cid = resp.into_inner().cid;
-                println!(
-                    "added {} {}",
-                    hooya::cid::encode(cid),
-                    Path::new(f).file_name().unwrap().to_str().unwrap()
-                );
+                stream_file_to_remote_filestore(client.clone(), f).await?;
+            }
+        }
+        Some(("add-dir", sub_matches)) => {
+            let dirs = sub_matches
+                .get_many::<PathBuf>("dirs")
+                .unwrap_or_default()
+                .collect::<Vec<_>>();
+            for d in &dirs {
+                stream_dir_to_remote_filestore(client.clone(), d).await?;
             }
         }
         Some(("tag", sub_matches)) => {
@@ -71,4 +84,43 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+async fn stream_file_to_remote_filestore(
+    mut client: ControlClient<Channel>,
+    local_file: &Path,
+) -> Result<()> {
+    let fh = File::open(local_file)?;
+    let chunks =
+        hooya::ChunkedReader::new(fh).map(|c| FileChunk { data: c.unwrap() });
+    let resp = client
+        .stream_to_filestore(futures_util::stream::iter(chunks))
+        .await
+        .map_err(anyhow::Error::new)?;
+    let cid = resp.into_inner().cid;
+    println!(
+        "added {} {}",
+        hooya::cid::encode(cid),
+        Path::new(local_file).file_name().unwrap().to_str().unwrap()
+    );
+
+    Ok(())
+}
+
+fn stream_dir_to_remote_filestore(
+    client: ControlClient<Channel>,
+    local_dir: &Path,
+) -> BoxFuture<Result<()>> {
+    Box::pin(async move {
+        for entry in std::fs::read_dir(local_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                stream_dir_to_remote_filestore(client.clone(), &path).await?;
+            } else {
+                stream_file_to_remote_filestore(client.clone(), &path).await?;
+            }
+        }
+        Ok(())
+    })
 }

--- a/packages/hooya/src/runtime.rs
+++ b/packages/hooya/src/runtime.rs
@@ -72,7 +72,7 @@ impl Runtime {
 
         // Keep /store kinda uncluttered by dividing data up into dirs
         let final_dir =
-            self.filestore_path.join("store").join(&encoded_cid[..6]);
+            self.filestore_path.join("store").join(&encoded_cid[..12]);
 
         // eg bafkreifh22[...] is stored at bafkre/bafkreifh22[...]
         final_dir.join(encoded_cid)


### PR DESCRIPTION
Add all files in a dir to a remote instance by walking it recursively with `hooya add-dir [dirs]`.

Benchmarking for posterity:

```
wesl-ee@divinity ~/code/hooya > find ~/img/hooya/to-import -type f | wc -l
3845
wesl-ee@divinity ~/code/hooya > du -h ~/img/hooya/to-import --max-depth=0
2.4G	/home/wesl-ee/img/hooya/to-import
wesl-ee@divinity ~/code/hooya > time ./target/release/hooya add-dir ~/img/hooya/to-import
real	0m23.585s
user	0m1.060s
sys	0m1.961s
```